### PR TITLE
also push image to github container registry (to be displayed on the repo)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,4 +36,4 @@ jobs:
           push: true
           tags: |
             ${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }} | cut -d'/' -f2):latest
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,7 @@ name: Docker Image CI
 on:
   push:
     branches: ['main']
+  workflow_dispatch:  # allow manual runs
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,11 @@ on:
     branches: ['main']
   workflow_dispatch:  # allow manual runs
 
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,11 +20,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      #- name: Login to DockerHub
-      #  uses: docker/login-action@v3
-      #  with:
-      #    username: ${{ secrets.DOCKER_USERNAME }}
-      #    password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -35,5 +40,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ github.repository }}:latest
+            flschmidt/campusunbloat-webapp:latest
             ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,11 +14,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
+      #- name: Login to DockerHub
+      #  uses: docker/login-action@v3
+      #  with:
+      #    username: ${{ secrets.DOCKER_USERNAME }}
+      #    password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push frontend
         uses: docker/build-push-action@v5
@@ -26,4 +33,6 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: flschmidt/campusunbloat-webapp:latest
+          tags: |
+            ${{ github.repository }}:latest
+            ghcr.io/${{ github.repository_owner }}/$(echo ${{ github.repository }} | cut -d'/' -f2):latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,4 +36,4 @@ jobs:
           push: true
           tags: |
             ${{ github.repository }}:latest
-            ghcr.io/${{ github.repository_owner }}/$(echo ${{ github.repository }} | cut -d'/' -f2):latest
+            ghcr.io/${{ github.repository }} | cut -d'/' -f2):latest


### PR DESCRIPTION
This PR adds the following to the docker image CI workflow:

- a login into the ghcr for pushing to it
- a second tag is added to the image, appropriate for the ghrc
- added the relevant permissions to the top of the workflow (this gives `GITHUB_TOKEN` the permission to push the image)
- added `workflow_dispatch` as trigger so that the workflow can be run manually by the repo owner if needed

Please note that my own testing on this is limited because I haven't taken the time to put my own docker.io credentials into my forks' env secrets to test a full run of the workflow